### PR TITLE
pop: Slightly tweak for reality

### DIFF
--- a/docs/pop.rst
+++ b/docs/pop.rst
@@ -89,10 +89,8 @@ and TLB misses.
 Requirements
 ============
 
-RPMs are typically the way that code is built and distributed both
-inside and outside of Red Hat.
 The implementation of the function reordering needs to be compatible
-with source RPMs used to build packages.
+with packaging tools such as RPM/dpkg for example.
 
 Where to put the profiling information? Red Hat has a build system to
 produce the RPM.


### PR DESCRIPTION
I am pretty sure if you take the way the world distributes software as a whole, by almost any metric, it would not be solely RPM.

Even at a simple basic mechanics perspective, surely (hopefully) it'd make sense to also try to support other package systems like dpkg/arch etc.

But here I just dropped the sentence about RPM being the sole way software is distributed as it's just clearly false.